### PR TITLE
Changes for Elixir 1.5.0

### DIFF
--- a/lib/tomlex/line.ex
+++ b/lib/tomlex/line.ex
@@ -39,19 +39,19 @@ defmodule Tomlex.Line do
         %LineTypes.Table{keys: parse_keys(table_names)}
       match = Regex.run(@float_regex, line) ->
         [_, key, value] = match
-        %LineTypes.Float{key: String.strip(key), value: String.strip(value)}
+        %LineTypes.Float{key: String.trim(key), value: String.trim(value)}
       match = Regex.run(@integer_regex, line) ->
         [_, key, value] = match
-        %LineTypes.Integer{key: String.strip(key), value: String.strip(value)}
+        %LineTypes.Integer{key: String.trim(key), value: String.trim(value)}
       match = Regex.run(@boolean_regex, line) ->
         [_, key, value] = match
-        %LineTypes.Boolean{key: String.strip(key), value: String.strip(value)}
+        %LineTypes.Boolean{key: String.trim(key), value: String.trim(value)}
       match = Regex.run(@array_regex, line) ->
         [_, key, value] = match
-        %LineTypes.Array{key: String.strip(key), values: ListParser.parse(value)}
+        %LineTypes.Array{key: String.trim(key), values: ListParser.parse(value)}
       match = Regex.run(@assignment_regex, line) ->
         [_, key, value] = match
-        %LineTypes.Assignment{key: String.strip(key), value: String.strip(value)}
+        %LineTypes.Assignment{key: String.trim(key), value: String.trim(value)}
       true ->
         %LineTypes.Blank{line: line}
     end

--- a/lib/tomlex/list_parser.ex
+++ b/lib/tomlex/list_parser.ex
@@ -34,7 +34,7 @@ defmodule Tomlex.ListParser do
   end
   defp parse_list(list, result) do
     { value_list, updated_rest } = list |> take_and_drop_while(&(&1 != ","))
-    value = StringHelpers.cast_string(value_list |> Enum.join |> String.strip)
+    value = StringHelpers.cast_string(value_list |> Enum.join |> String.trim)
     parse_list(updated_rest, result ++ [value])
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule Tomlex.Mixfile do
      version: "0.0.4",
      elixir: ">= 1.0.0",
      description: "A TOML parser for elixir",
-     package: package,
+     package: package(),
      source_url: "https://github.com/zamith/tomlex",
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Since elixir 1.5.0, `String.strip/1` is deprecated instead `String.trim/1` has to be used.

Also elixir gives warnings when a zero arity function is called without parentheses.